### PR TITLE
Remove duplicate models by loading the liberty ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+stat/*.stat
+sim/*.v
+sim/*.vcd
+sim/*.vvp

--- a/74_models.v
+++ b/74_models.v
@@ -1,27 +1,3 @@
-module \74AC151_1x1MUX8 (D, S, O);
-
-input [7:0] D;
-input [2:0] S;
-output O;
-
-assign O = S[2] ? (S[1] ? (S[0] ? D[7] : D[6])
-                        : (S[0] ? D[5] : D[4]))
-                : (S[1] ? (S[0] ? D[3] : D[2])
-                        : (S[0] ? D[1] : D[0]));
-
-endmodule
-
-module \74AC153_2x1MUX4 (D, S, O);
-
-input [3:0] D;
-input [1:0] S;
-output O;
-
-assign O = S[1] ? (S[0] ? D[3] : D[2])
-                : (S[0] ? D[1] : D[0]);
-
-endmodule
-
 module \74AC283_1x1ADD4 (A, B, CI, S, CO);
 
 input [3:0] A;

--- a/74_mux.v
+++ b/74_mux.v
@@ -5,9 +5,13 @@ input A, B, C, D, S, T;
 output Y;
 
 \74AC153_2x1MUX4 _TECHMAP_REPLACE_ (
-    .S({T, S}),
-    .D({D, C, B, A}),
-    .O(Y)
+    .A(A),
+    .B(B),
+    .C(C),
+    .D(D),
+    .S0(S),
+    .S1(T),
+    .Y(Y)
 );
 
 endmodule
@@ -19,9 +23,18 @@ input A, B, C, D, E, F, G, H, S, T, U;
 output Y;
 
 \74AC151_1x1MUX8 _TECHMAP_REPLACE_ (
-    .S({U, T, S}),
-    .D({H, G, F, E, D, C, B, A}),
-    .O(Y)
+    .A(A),
+    .B(B),
+    .C(C),
+    .D(D),
+    .E(E),
+    .F(F),
+    .G(G),
+    .H(H),
+    .S0(S),
+    .S1(T),
+    .S2(U),
+    .Y(Y)
 );
 
 endmodule

--- a/74series.lib
+++ b/74series.lib
@@ -196,8 +196,8 @@ library(74series) {
         pin(Y) { direction: output; function: "A"; }
     }
 
-    // 7416373 sixteen D flip-flop
-    cell(74AC16373_16x1DFF) {
+    // 7416374 sixteen D flip-flop
+    cell(74AC16374_16x1DFF) {
         area: 3;
         ff(IQ, IQN) { clocked_on: "CLK"; next_state: "D"; }
         pin(CLK) { direction: input; clock: true; }

--- a/74series.lib
+++ b/74series.lib
@@ -137,7 +137,7 @@ library(74series) {
         pin(S1) { direction: input; }
         pin(S2) { direction: input; }
         pin(Y) { direction: output;
-        function: "(S0'*S1'*S2'*A)+(S0'*S1'*S2*B)+(S0'*S1*S2'*C)+(S0'*S1*S2*D)+(S0*S1'*S2'*E)+(S0*S1'*S2*F)+(S0*S1*S2'*G)+(S0*S1*S2*H)"; }
+        function: "(S0'*S1'*S2'*A)+(S0*S1'*S2'*B)+(S0'*S1*S2'*C)+(S0*S1*S2'*D)+(S0'*S1'*S2*E)+(S0*S1'*S2'*F)+(S0'*S1*S2*G)+(S0*S1*S2*H)"; }
     }
 
     // 74AC151 single 8:1 multiplexer, inverting output
@@ -155,7 +155,7 @@ library(74series) {
         pin(S1) { direction: input; }
         pin(S2) { direction: input; }
         pin(Y) { direction: output;
-        function: "((S0'*S1'*S2'*A)+(S0'*S1'*S2*B)+(S0'*S1*S2'*C)+(S0'*S1*S2*D)+(S0*S1'*S2'*E)+(S0*S1'*S2*F)+(S0*S1*S2'*G)+(S0*S1*S2*H))'"; }
+        function: "((S0'*S1'*S2'*A)+(S0*S1'*S2'*B)+(S0'*S1*S2'*C)+(S0*S1*S2'*D)+(S0'*S1'*S2*E)+(S0*S1'*S2'*F)+(S0'*S1*S2*G)+(S0*S1*S2*H))'"; }
     }
 
 
@@ -168,7 +168,7 @@ library(74series) {
         pin(D) { direction: input; }
         pin(S0) { direction: input; }
         pin(S1) { direction: input; }
-        pin(Y) { direction: output; function: "((S0'*S1'*A)+(S0'*S1*B)+(S0*S1'*C)+(S0*S1*D))"; }
+        pin(Y) { direction: output; function: "((S0'*S1'*A)+(S0*S1'*B)+(S0'*S1*C)+(S0*S1*D))"; }
     }
 
     // 74AC11257 quad 2:1 multiplexer

--- a/benchmarks/cic5.v
+++ b/benchmarks/cic5.v
@@ -1,0 +1,65 @@
+// 5th order CIC filter with decimation factor of 5
+// Author: Niels A. Moseley
+//         Symbiotic EDA / Moseley Instruments
+// 12-11-2018
+
+module cic5(
+    input  clk, 
+    input  rst_n, 
+    input  signed [15:0] d_in, 
+    output reg signed [27:0] d_out, 
+    output reg d_out_valid
+    );
+
+reg signed [27:0] int_s  [1:5]; // integrator states
+reg signed [27:0] comb_s [1:5]; // comb filter states
+reg signed [27:0] tmp    [1:5];    // temporary var
+reg [2:0]  decimation_count;
+
+integer i;
+
+    always @(posedge clk)
+    begin
+        if (rst_n == 1'b0)
+        begin
+            for (i=1; i<=5; i=i+1) begin
+                int_s[i]  <= 16'd0;
+                comb_s[i] <= 28'd0;
+            end
+            decimation_count <= 0;            
+            d_out_valid <= 0;
+            d_out <= 0;
+        end
+        else
+        begin
+            // default updates
+            d_out_valid <= 1'b0;
+            decimation_count <= decimation_count + 1;
+
+            // update the integrator filter states
+            int_s[1] <= int_s[1] + d_in;
+            for (i=2; i<=5; i=i+1) begin
+                int_s[i] <= int_s[i] + int_s[i-1];
+            end
+
+            // check if we can output new data
+            // at the decimated rate
+            
+            if (decimation_count == 3'd4)
+            begin
+                // update the comb filter states
+                tmp[1] = int_s[5] - comb_s[1];
+                comb_s[1] <= int_s[5];
+                for (i=2; i<=5; i=i+1) begin
+                    tmp[i] = tmp[i-1] - comb_s[i];
+                    comb_s[i] <= tmp[i-1];
+                end
+
+                decimation_count <= 0;
+                d_out_valid <= 1'b1;
+                d_out <= tmp[5];
+            end;
+        end;
+    end
+
+endmodule

--- a/benchmarks/cic5_tb.v
+++ b/benchmarks/cic5_tb.v
@@ -1,0 +1,32 @@
+// Testbench for 5th order CIC filter with decimation factor of 5
+// Author: Niels A. Moseley
+//         Symbiotic EDA / Moseley Instruments
+//
+// 12-11-2018
+
+
+module tb;
+
+reg  clk   = 0;
+reg  rst_n = 0;
+reg  signed [15:0] d_in = 0;
+wire signed [27:0] d_out = 0;
+wire d_out_valid;
+
+// clock generation
+always #1 clk=~clk;
+
+// devices under test
+cic5 dut(clk, rst_n, d_in, d_out, d_out_valid);
+
+initial
+begin
+    $dumpfile("cic5.vcd");
+    $dumpvars;
+    d_in     <= 16'h7fff;
+    #4 rst_n = 1'b1;
+    #60 d_in <= -16'h7fff;
+    #60 $finish;
+end
+
+endmodule

--- a/benchmarks/counter.v
+++ b/benchmarks/counter.v
@@ -1,0 +1,28 @@
+// Quick blinking a LED
+
+/* module */
+module counter (
+  input rst,
+  input clk,
+  output led
+    
+);
+
+    /* reg */
+    reg [7:0] counter = 0;
+    reg state;
+    
+    /* assign */
+    assign led = state;
+    
+    /* always */
+    always @ (posedge clk) begin
+      if (rst) begin
+        counter <= 0;
+      end else begin
+        counter <= counter + 1;
+        state <= counter[7];
+      end
+    end
+
+endmodule

--- a/benchmarks/counter_tb.v
+++ b/benchmarks/counter_tb.v
@@ -1,0 +1,22 @@
+module counter_tb ();
+ 
+  reg clk, rst;
+  wire led;
+ 
+  counter DUT (
+    .rst(rst),
+    .clk(clk),
+    .led(led)
+  );
+ 
+  initial begin
+    $dumpfile("counter.vcd");
+    $dumpvars(0,counter_tb);
+    clk = 1'b0;
+    rst = 1'b1;
+    repeat(4) #10 clk = ~clk;
+    rst = 1'b0;
+    repeat(1024) #10 clk = ~clk;
+  end
+ 
+endmodule

--- a/benchmarks/dspmac_16_40.v
+++ b/benchmarks/dspmac_16_40.v
@@ -1,0 +1,43 @@
+// DSP multiply-and-accumulate block without saturation
+// Author: Niels A. Moseley
+
+module dspmac_16_40(
+    input clk, 
+    input rst_n, 
+    input [1:0] opcode,
+    input signed [16-1:0] a_in, 
+    input signed [16-1:0] b_in, 
+    output signed [40-1:0] accu_out
+    );
+
+reg signed [40-1:0] accu;
+
+parameter [1:0] OP_CLR = 2'b00,
+                OP_MUL = 2'b01,
+                OP_MAC = 2'b10,
+                OP_NOP = 2'b11;    
+
+always @(posedge clk or negedge rst_n)
+begin
+    if (rst_n == 1'b0)
+        accu <= 40'd0;  // set accumulator to zero
+    else
+    begin
+        case(opcode)
+        OP_CLR:
+            accu <= 0;
+        OP_MUL:
+            accu <= a_in*b_in;
+        OP_MAC:
+            accu <= accu+a_in*b_in;
+        OP_NOP:
+            accu <= accu;
+        default:
+            accu <= accu;
+        endcase
+    end
+end
+
+assign accu_out = accu;
+
+endmodule

--- a/benchmarks/dspmac_16_40_tb.v
+++ b/benchmarks/dspmac_16_40_tb.v
@@ -1,0 +1,39 @@
+// Testbench for sddac.v
+// Author: Niels A. Moseley
+
+`include "constants.vams"
+
+module tb;
+
+reg  clk   = 0;
+reg  rst_n = 0;
+reg  [1:0] opcode = 2'b11;      // nop
+reg  signed [15:0] a_bus = 0;
+reg  signed [15:0] b_bus = 0;
+wire signed [39:0] result;
+
+// clock generation
+always #1 clk=~clk;
+
+// devices under test
+dspmac_16_40 dut(clk, rst_n, opcode, a_bus, b_bus, result);
+
+initial
+begin
+    $dumpfile("dspmac_16_40.vcd");
+    $dumpvars;
+
+    opcode = 2'b00;     //CLR
+
+    #4 rst_n = 1'b1;
+    a_bus    = 16'd32767;
+    b_bus    = 16'd32767;
+    opcode   = 2'b01;       // MUL
+    #2 opcode   = 2'b10;    // MAC
+    #2 opcode   = 2'b11;    // NOP
+    #2 opcode   = 2'b11;    // NOP
+    #2 $finish;
+    
+end
+
+endmodule

--- a/benchmarks/picorv32.v
+++ b/benchmarks/picorv32.v
@@ -54,6 +54,7 @@
  * picorv32
  ***************************************************************/
 
+(* top *)
 module picorv32 #(
 	parameter [ 0:0] ENABLE_COUNTERS = 1,
 	parameter [ 0:0] ENABLE_COUNTERS64 = 1,

--- a/benchmarks/picorv32_tb.v
+++ b/benchmarks/picorv32_tb.v
@@ -1,0 +1,84 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+`timescale 1 ns / 1 ps
+
+module testbench;
+	reg clk = 1;
+	reg resetn = 0;
+	wire trap;
+
+	always #5 clk = ~clk;
+
+	initial begin
+    $dumpfile("picorv32.vcd");
+    $dumpvars(0, testbench);
+		repeat (100) @(posedge clk);
+		resetn <= 1;
+		repeat (1000) @(posedge clk);
+		$finish;
+	end
+
+	wire mem_valid;
+	wire mem_instr;
+	reg mem_ready;
+	wire [31:0] mem_addr;
+	wire [31:0] mem_wdata;
+	wire [3:0] mem_wstrb;
+	reg  [31:0] mem_rdata;
+
+	always @(posedge clk) begin
+		if (mem_valid && mem_ready) begin
+			if (mem_instr)
+				$display("ifetch 0x%08x: 0x%08x", mem_addr, mem_rdata);
+			else if (mem_wstrb)
+				$display("write  0x%08x: 0x%08x (wstrb=%b)", mem_addr, mem_wdata, mem_wstrb);
+			else
+				$display("read   0x%08x: 0x%08x", mem_addr, mem_rdata);
+		end
+	end
+
+	picorv32 #(
+	) uut (
+		.clk         (clk        ),
+		.resetn      (resetn     ),
+		.trap        (trap       ),
+		.mem_valid   (mem_valid  ),
+		.mem_instr   (mem_instr  ),
+		.mem_ready   (mem_ready  ),
+		.mem_addr    (mem_addr   ),
+		.mem_wdata   (mem_wdata  ),
+		.mem_wstrb   (mem_wstrb  ),
+		.mem_rdata   (mem_rdata  )
+	);
+
+	reg [31:0] memory [0:255];
+
+	initial begin
+		memory[0] = 32'h 3fc00093; //       li      x1,1020
+		memory[1] = 32'h 0000a023; //       sw      x0,0(x1)
+		memory[2] = 32'h 0000a103; // loop: lw      x2,0(x1)
+		memory[3] = 32'h 00110113; //       addi    x2,x2,1
+		memory[4] = 32'h 0020a023; //       sw      x2,0(x1)
+		memory[5] = 32'h ff5ff06f; //       j       <loop>
+	end
+
+	always @(posedge clk) begin
+		mem_ready <= 0;
+		if (mem_valid && !mem_ready) begin
+			if (mem_addr < 1024) begin
+				mem_ready <= 1;
+				mem_rdata <= memory[mem_addr >> 2];
+				if (mem_wstrb[0]) memory[mem_addr >> 2][ 7: 0] <= mem_wdata[ 7: 0];
+				if (mem_wstrb[1]) memory[mem_addr >> 2][15: 8] <= mem_wdata[15: 8];
+				if (mem_wstrb[2]) memory[mem_addr >> 2][23:16] <= mem_wdata[23:16];
+				if (mem_wstrb[3]) memory[mem_addr >> 2][31:24] <= mem_wdata[31:24];
+			end
+			/* add memory-mapped IO here */
+		end
+	end
+endmodule

--- a/benchmarks/pwm256.v
+++ b/benchmarks/pwm256.v
@@ -1,0 +1,32 @@
+// 256-level PWM generator
+// Author: Niels A. Moseley
+//         Symbiotic EDA / Moseley Instruments
+//         10-11-2018
+
+module pwm256(
+    input clk, 
+    input rst_n, 
+    input [7:0] d_in,
+    output reg pwm_out
+);
+
+reg signed [7:0] counter;
+
+always @(posedge clk or negedge rst_n)
+begin
+    if (rst_n == 1'b0)
+    begin
+        counter <= 8'd0;
+        pwm_out <= 1'b0;
+    end
+    else
+    begin
+        counter <= counter + 8'd1;
+        if (counter >= d_in)
+            pwm_out <= 1'b1;
+        else
+            pwm_out <= 1'b0;
+    end
+end
+
+endmodule

--- a/benchmarks/pwm256_tb.v
+++ b/benchmarks/pwm256_tb.v
@@ -1,0 +1,31 @@
+// Testbench for 256-level PWM generator
+// Author: Niels A. Moseley
+//         Symbiotic EDA / Moseley Instruments
+//         10-11-2018
+
+module tb;
+
+reg  clk   = 0;
+reg  rst_n = 0;
+reg  [7:0] d_in  = 8'd128;
+wire pwm;
+
+// clock generation
+always #1 clk=~clk;
+
+// devices under test
+pwm256 dut(clk, rst_n, d_in, pwm);
+
+initial
+begin
+    $dumpfile("pwm256.vcd");
+    $dumpvars;
+
+    #4 rst_n = 1'b1;
+    #516 d_in = 8'd10;
+    #1028 d_in = 8'd246;
+    #1540 $finish;
+    
+end
+
+endmodule

--- a/benchmarks/sddac.v
+++ b/benchmarks/sddac.v
@@ -1,0 +1,72 @@
+// Second order sigma-delta dac
+//
+// For benchmarking purposes only -- don't use this for an actual design.
+// There are far more performant architectures. 
+// 
+// Author: Niels A. Moseley, n.a.moseley@moseleyinstruments.com
+//
+
+`ifdef DEBUG_SDDAC
+`include "constants.vams"
+`endif
+
+module sddac(clk, rst_n, sig_in, sd_out);
+
+    // inputs
+    input clk;                          // clock
+    input rst_n;                        // synchronous reset, active low
+    input signed [15:0] sig_in;         // 16 bits in Q(1,15) format
+
+    // outputs
+    output reg sd_out = 0;
+
+    // internal signals
+    reg signed [17:0] state1 = 0;       // Q(1,17)
+    reg signed [19:0] state2 = 0;       // Q(1,19)
+    reg signed [16:0] state1_in;        // Q(0,17)
+    reg signed [18:0] state2_in;        // Q(0,19)
+    reg signed [20:0] quant_in;         // Q(2,19)
+    reg signed [16:0] qq;
+    reg        [7:0]  lfsr_reg = 0;
+    reg               quantizer;
+    wire lfsr_fb;
+
+    // linear feedback shift register feedback
+    assign lfsr_fb = (lfsr_reg[4] ^ lfsr_reg[2]);
+
+    // combination process
+    always @(*)
+    begin
+        `ifdef DEBUG_SDDAC
+        qq = $signed(quantizer ? -17'h8000 : 17'h8000);
+        `endif
+        quant_in  = state2 + $signed(lfsr_fb ? -21'h4000 : 21'h4000);
+        quantizer = quant_in[20];
+        state1_in = sig_in - $signed(quantizer ? -17'h8000 : 17'h8000);        // Q(-1,17) - Q(0,17) -> Q(0,17)
+        state2_in = state1 - $signed(quantizer ? -19'h10000 : 19'h10000);      // Q(-1,19) - Q(0,19) -> Q(0,19)
+    end
+
+    // clocked process
+    always @(posedge clk)
+    begin
+        if (rst_n == 1'b0)
+        begin
+            state1 <= 0;
+            state2 <= 0;
+            lfsr_reg <= 8'hff;
+        end
+        else begin
+            `ifdef DEBUG_SDDAC
+            $display("feedback : %f", qq*$pow(2.0,-15));
+            $display("state1_in: %f", state1_in*$pow(2.0,-17));
+            $display("state2_in: %f", state2_in*$pow(2.0,-19));
+            $display("");
+            `endif
+            state1 <= state1 + $signed({ state1_in[16], state1_in});
+            state2 <= state2 + $signed({ state2_in[18], state2_in});
+            sd_out <= !quantizer;
+            lfsr_reg <= {lfsr_reg[6:0], lfsr_fb};
+        end
+    end
+
+endmodule

--- a/benchmarks/sddac_tb.v
+++ b/benchmarks/sddac_tb.v
@@ -1,0 +1,44 @@
+// Testbench for sddac.v
+// Author: Niels A. Moseley
+
+`include "constants.vams"
+
+module tb;
+
+reg  clk   = 0;
+reg  rst_n = 0;
+reg signed [15:0] sig = 0;
+wire dac_out;
+
+real    phase = 0.0;
+integer fhandle;
+
+// clock generation
+always #1 clk=~clk;
+
+// devices under test
+sddac dut(clk, rst_n, sig, dac_out);
+
+initial
+begin
+    $dumpfile("sddac.vcd");
+    $dumpvars;
+
+    fhandle = $fopen("sddac_out.txt","w");
+
+    #4 rst_n = 1'b1;
+
+    #526288 $finish;    // 2^18 + 1000 startup samples
+end
+
+always @(posedge clk)
+begin
+    if (rst_n == 1'b1)
+    begin
+        $fwrite(fhandle, "%d\n", dac_out);
+        sig <= $sin(`M_TWO_PI*phase)*10000.0;
+        phase <= phase + 0.001;
+    end
+end
+
+endmodule

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all clean sim_counter
+.SECONDARY:
+
+all: sim_counter sim_picorv32
+
+%.v: ../%.lib
+	yosys -q -p "read_liberty $<" -p "write_verilog $@"
+
+../benchmarks/%.v: ;
+
+%.v: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_dffe.v ../74_mux.v ../synth_74.ys
+	yosys -q -s ../synth_74.ys -p "write_verilog $@" $<
+
+%.vvp: %.v ../benchmarks/%_tb.v 74series.v ../74_models.v
+	iverilog -o $@ $^
+
+sim_counter: counter.vvp
+	vvp counter.vvp
+
+sim_picorv32: picorv32.vvp
+	vvp picorv32.vvp
+
+clean:
+	rm *.v *.vvp *.vcd

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean sim_counter
 .SECONDARY:
 
-all: sim_counter sim_picorv32
+all: counter.vcd cic5.vcd dspmac_16_40.vcd pwm256.vcd sddac.vcd picorv32.vcd
 
 %.v: ../%.lib
 	yosys -q -p "read_liberty $<" -p "write_verilog $@"
@@ -14,11 +14,8 @@ all: sim_counter sim_picorv32
 %.vvp: %.v ../benchmarks/%_tb.v 74series.v ../74_models.v
 	iverilog -o $@ $^
 
-sim_counter: counter.vvp
-	vvp counter.vvp
-
-sim_picorv32: picorv32.vvp
-	vvp picorv32.vvp
+%.vcd: %.vvp
+	vvp $<
 
 clean:
 	rm *.v *.vvp *.vcd

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -10,6 +10,7 @@ opt_merge
 dff2dffe -unmap-mince 8
 pmux2shiftx
 read_verilog -lib ../74_models.v
+read_liberty -lib ../74series.lib
 techmap -map ../74_adder.v
 synth -run :fine
 opt -full


### PR DESCRIPTION
When simulating generated designs by generating verilog models for the liberty cells, I ran into conflicts between the verilog and liberty models. But yosys can load the liberty models, so the verilog ones can be removed.