### PR TITLE
Improve reset synthezation

### DIFF
--- a/74series.lib
+++ b/74series.lib
@@ -99,6 +99,7 @@ library(74series) {
 
     // 74AC11074 dual D flip-flop with set and reset
     cell(74AC11074_2x1DFFSR) {
+        area: 5;
         ff(IQ, IQN) {
            clocked_on: "CLK";
            next_state: "D";
@@ -110,6 +111,20 @@ library(74series) {
         pin(CLK) { direction: input; clock: true; }
         pin(C) { direction: input; }
         pin(P) { direction: input; }
+        pin(D) { direction: input; }
+        pin(Q) { direction: output; function: "IQ"; }
+    }
+
+    // 74AC273 octal D flip-flop with common reset
+    cell(74AC273_8x1DFFR) {
+	area: 2.25; // amortized clock and reset cost
+        ff(IQ, IQN) {
+           clocked_on: "CLK";
+           next_state: "D";
+           clear: "C'";
+        }
+        pin(CLK) { direction: input; clock: true; }
+        pin(C) { direction: input; }
         pin(D) { direction: input; }
         pin(Q) { direction: output; function: "IQ"; }
     } 
@@ -198,7 +213,7 @@ library(74series) {
 
     // 7416374 sixteen D flip-flop
     cell(74AC16374_16x1DFF) {
-        area: 3;
+        area: 2.0625; // amortized clock pin cost
         ff(IQ, IQN) { clocked_on: "CLK"; next_state: "D"; }
         pin(CLK) { direction: input; clock: true; }
         pin(D) { direction: input; }

--- a/benchmarks/counter.v
+++ b/benchmarks/counter.v
@@ -16,8 +16,8 @@ module counter (
     assign led = state;
     
     /* always */
-    always @ (posedge clk) begin
-      if (rst) begin
+    always @ (posedge clk or negedge rst) begin
+      if (!rst) begin
         counter <= 0;
       end else begin
         counter <= counter + 1;

--- a/benchmarks/counter.v
+++ b/benchmarks/counter.v
@@ -13,7 +13,7 @@ module counter (
     reg state;
     
     /* assign */
-    assign led = state;
+    assign led = counter[7];
     
     /* always */
     always @ (posedge clk or negedge rst) begin
@@ -21,7 +21,6 @@ module counter (
         counter <= 0;
       end else begin
         counter <= counter + 1;
-        state <= counter[7];
       end
     end
 


### PR DESCRIPTION
When I synthesize a simple counter, I get pretty much what you'd expect

     \74AC16374_16x1DFF              9
     \74AC283_1x1ADD4                2

But when using a reset, a lot of extra stuff is generated. For active-high synchronous reset it basically uses muxes and a bunch of random things.

     \74AC02_4x1NOR2                 8
     \74AC11004_6x1NOT               8
     \74AC11257_4x1MUX2              1
     \74AC16374_16x1DFF              9
     \74AC283_1x1ADD4                2

For asynchronous active low reset, it does a lot better and actually uses the resettable DFF, but with 2 flip-flops in a 14 pin package, it's not very efficient:

     \74AC11074_2x1DFFSR             8
     \74AC16374_16x1DFF              1
     \74AC283_1x1ADD4                2

So there are two ways I think we can do better:

For synchronous reset, it'd be useful to find a DFF that supports it. The liberty syntax seems to be as follows, but Yosys says it's not supported.

    ff(IQ, IQN) {
        next_state : "D * CLR";
        clocked_on : "CP" ;
    }

There are a large variety of chips that have a common clear. I would say the common case for a reset is to set everything to zero, so if there is a way to teach Yosys about them, it'd be a lot more efficient.

Some candidates I've found:

74x575 octal D-type edge-triggered flip-flop, synchronous clear
74x273 8-bit register, asynchronous clear

I added the 74x273.
However, it seems the 575 is not in production anywhere. So I guess the conclusion is, don't do synchronous reset in 74xx logic.

I've also updated the area of some chips to account for shared pins.

What's a bit unfortunate is that the 74AC11074 has a inverted output that ABC won't like.
Would it make sense to make a copy of it that only exposes the inverted output?
Might save a few not gates here and there.

After these changes, the counter with reset results in

     \74AC273_8x1DFFR                8
     \74AC283_1x1ADD4                2
