### PR TITLE
Implement magnitude comparator passes

### DIFF
--- a/74_adder.v
+++ b/74_adder.v
@@ -28,7 +28,7 @@ assign C[0] = 0;
 
 genvar i;
 generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
-    \74AC283_1x1ADD4 adder_i (
+    \74AC283_1x1ADD4 adder_i(
         .A(AA[i+3:i]),
         .B(BB[i+3:i]),
         .CI(C[i]),

--- a/74_cmp.v
+++ b/74_cmp.v
@@ -1,0 +1,196 @@
+(* techmap_celltype = "$lt" *)
+module _80_74HC85_lt (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
+
+localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH:0] G;
+wire [WIDTH:0] E;
+wire [WIDTH:0] L;
+
+assign G[0] = 0;
+assign E[0] = 1;
+assign L[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
+    \74HC85_1x1CMP4 cmp_i(
+        .A(AA[i+3:i]),
+        .B(BB[i+3:i]),
+        .Li(L[i]),
+        .Ei(E[i]),
+        .Gi(G[i]),
+        .Lo(L[i+4]),
+        .Eo(E[i+4]),
+        .Go(G[i+4])
+    );
+end
+endgenerate
+
+assign Y = L[WIDTH];
+
+endmodule
+
+(* techmap_celltype = "$gt" *)
+module _80_74HC85_gt (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
+localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH:0] G;
+wire [WIDTH:0] E;
+wire [WIDTH:0] L;
+
+assign G[0] = 0;
+assign E[0] = 1;
+assign L[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
+    \74HC85_1x1CMP4 cmp_i(
+        .A(AA[i+3:i]),
+        .B(BB[i+3:i]),
+        .Li(L[i]),
+        .Ei(E[i]),
+        .Gi(G[i]),
+        .Lo(L[i+4]),
+        .Eo(E[i+4]),
+        .Go(G[i+4])
+    );
+end
+endgenerate
+
+assign Y = G[WIDTH];
+
+endmodule
+
+(* techmap_celltype = "$le" *)
+module _80_74HC85_le (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
+localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH:0] G;
+wire [WIDTH:0] E;
+wire [WIDTH:0] L;
+
+assign G[0] = 0;
+assign E[0] = 1;
+assign L[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
+    \74HC85_1x1CMP4 cmp_i(
+        .A(AA[i+3:i]),
+        .B(BB[i+3:i]),
+        .Li(L[i]),
+        .Ei(E[i]),
+        .Gi(G[i]),
+        .Lo(L[i+4]),
+        .Eo(E[i+4]),
+        .Go(G[i+4])
+    );
+end
+endgenerate
+
+assign Y = !G[WIDTH];
+
+endmodule
+
+(* techmap_celltype = "$ge" *)
+module _80_74HC85_ge (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
+localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH:0] G;
+wire [WIDTH:0] E;
+wire [WIDTH:0] L;
+
+assign G[0] = 0;
+assign E[0] = 1;
+assign L[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
+    \74HC85_1x1CMP4 cmp_i(
+        .A(AA[i+3:i]),
+        .B(BB[i+3:i]),
+        .Li(L[i]),
+        .Ei(E[i]),
+        .Gi(G[i]),
+        .Lo(L[i+4]),
+        .Eo(E[i+4]),
+        .Go(G[i+4])
+    );
+end
+endgenerate
+
+assign Y = !L[WIDTH];
+
+endmodule

--- a/74_cmp.v
+++ b/74_cmp.v
@@ -13,11 +13,12 @@ output [Y_WIDTH-1:0] Y;
 
 wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
 
-localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+localparam MAX_WIDTH = (A_WIDTH > B_WIDTH) ? A_WIDTH : B_WIDTH;
+localparam WIDTH = ((MAX_WIDTH + 3) / 4) * 4;
 
-wire [Y_WIDTH-1:0] A_buf, B_buf;
-\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
-\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+wire [MAX_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(MAX_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(MAX_WIDTH)) B_conv (.A(B), .Y(B_buf));
 
 wire [WIDTH-1:0] AA = A_buf;
 wire [WIDTH-1:0] BB = B_buf;
@@ -62,11 +63,12 @@ input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
 wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
-localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+localparam MAX_WIDTH = (A_WIDTH > B_WIDTH) ? A_WIDTH : B_WIDTH;
+localparam WIDTH = ((MAX_WIDTH + 3) / 4) * 4;
 
-wire [Y_WIDTH-1:0] A_buf, B_buf;
-\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
-\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+wire [MAX_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(MAX_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(MAX_WIDTH)) B_conv (.A(B), .Y(B_buf));
 
 wire [WIDTH-1:0] AA = A_buf;
 wire [WIDTH-1:0] BB = B_buf;
@@ -111,11 +113,12 @@ input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
 wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
-localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+localparam MAX_WIDTH = (A_WIDTH > B_WIDTH) ? A_WIDTH : B_WIDTH;
+localparam WIDTH = ((MAX_WIDTH + 3) / 4) * 4;
 
-wire [Y_WIDTH-1:0] A_buf, B_buf;
-\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
-\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+wire [MAX_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(MAX_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(MAX_WIDTH)) B_conv (.A(B), .Y(B_buf));
 
 wire [WIDTH-1:0] AA = A_buf;
 wire [WIDTH-1:0] BB = B_buf;
@@ -160,11 +163,12 @@ input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
 wire _TECHMAP_FAIL_ = A_WIDTH <= 3 && B_WIDTH <= 3;
-localparam WIDTH = ((Y_WIDTH + 3) / 4) * 4;
+localparam MAX_WIDTH = (A_WIDTH > B_WIDTH) ? A_WIDTH : B_WIDTH;
+localparam WIDTH = ((MAX_WIDTH + 3) / 4) * 4;
 
-wire [Y_WIDTH-1:0] A_buf, B_buf;
-\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
-\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+wire [MAX_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(MAX_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(MAX_WIDTH)) B_conv (.A(B), .Y(B_buf));
 
 wire [WIDTH-1:0] AA = A_buf;
 wire [WIDTH-1:0] BB = B_buf;

--- a/74_eq.v
+++ b/74_eq.v
@@ -9,12 +9,16 @@ parameter B_SIGNED = 0;
 parameter A_WIDTH = 0;
 parameter B_WIDTH = 0;
 parameter Y_WIDTH = 0;
+parameter _TECHMAP_CONSTMSK_A_ = 0;
+parameter _TECHMAP_CONSTVAL_A_ = 0;
+parameter _TECHMAP_CONSTMSK_B_ = 0;
+parameter _TECHMAP_CONSTVAL_B_ = 0;
 
 input [A_WIDTH-1:0] A;
 input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
-wire _TECHMAP_FAIL_ = A_WIDTH <= 6 && B_WIDTH <= 6;
+wire _TECHMAP_FAIL_ = (A_WIDTH <= 6 && B_WIDTH <= 6) || &_TECHMAP_CONSTMSK_A_ || &_TECHMAP_CONSTMSK_B_;
 
 localparam WIDTH = ((Y_WIDTH + 7) / 8) * 8;
 
@@ -52,12 +56,16 @@ parameter B_SIGNED = 0;
 parameter A_WIDTH = 0;
 parameter B_WIDTH = 0;
 parameter Y_WIDTH = 0;
+parameter _TECHMAP_CONSTMSK_A_ = 0;
+parameter _TECHMAP_CONSTVAL_A_ = 0;
+parameter _TECHMAP_CONSTMSK_B_ = 0;
+parameter _TECHMAP_CONSTVAL_B_ = 0;
 
 input [A_WIDTH-1:0] A;
 input [B_WIDTH-1:0] B;
 output [Y_WIDTH-1:0] Y;
 
-wire _TECHMAP_FAIL_ = A_WIDTH <= 8 && B_WIDTH <= 8;
+wire _TECHMAP_FAIL_ = (A_WIDTH <= 6 && B_WIDTH <= 6) || &_TECHMAP_CONSTMSK_A_ || &_TECHMAP_CONSTMSK_B_;
 
 localparam WIDTH = ((Y_WIDTH + 7) / 8) * 8;
 

--- a/74_eq.v
+++ b/74_eq.v
@@ -1,0 +1,88 @@
+// Note: this file is kept around for posterity; ABC is very good at
+// optimising equality checks.
+
+(* techmap_celltype = "$eq" *)
+module _80_74HC688_eq (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 6 && B_WIDTH <= 6;
+
+localparam WIDTH = ((Y_WIDTH + 7) / 8) * 8;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH-1:0] YY;
+wire [WIDTH:0] C;
+
+assign C[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 8) begin:slice
+    \74HC688_1x1EQ8 eq_i (
+        .A(AA[i+7:i]),
+        .B(BB[i+7:i]),
+        .E(C[i]),
+        .Q(C[i+8])
+    );
+end
+endgenerate
+
+assign Y = !C[WIDTH];
+
+endmodule
+
+(* techmap_celltype = "$ne" *)
+module _80_74HC688_ne (A, B, Y);
+
+parameter A_SIGNED = 0;
+parameter B_SIGNED = 0;
+parameter A_WIDTH = 0;
+parameter B_WIDTH = 0;
+parameter Y_WIDTH = 0;
+
+input [A_WIDTH-1:0] A;
+input [B_WIDTH-1:0] B;
+output [Y_WIDTH-1:0] Y;
+
+wire _TECHMAP_FAIL_ = A_WIDTH <= 8 && B_WIDTH <= 8;
+
+localparam WIDTH = ((Y_WIDTH + 7) / 8) * 8;
+
+wire [Y_WIDTH-1:0] A_buf, B_buf;
+\$pos #(.A_SIGNED(A_SIGNED), .A_WIDTH(A_WIDTH), .Y_WIDTH(Y_WIDTH)) A_conv (.A(A), .Y(A_buf));
+\$pos #(.A_SIGNED(B_SIGNED), .A_WIDTH(B_WIDTH), .Y_WIDTH(Y_WIDTH)) B_conv (.A(B), .Y(B_buf));
+
+wire [WIDTH-1:0] AA = A_buf;
+wire [WIDTH-1:0] BB = B_buf;
+wire [WIDTH-1:0] YY;
+wire [WIDTH:0] C;
+
+assign C[0] = 0;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 8) begin:slice
+    \74HC688_1x1EQ8 eq_i (
+        .A(AA[i+7:i]),
+        .B(BB[i+7:i]),
+        .E(C[i]),
+        .Q(C[i+8])
+    );
+end
+endgenerate
+
+assign Y = C[WIDTH];
+
+endmodule

--- a/74_models.v
+++ b/74_models.v
@@ -1,3 +1,16 @@
+module \74HC85_1x1CMP4 (A, B, Li, Ei, Gi, Lo, Eo, Go);
+
+input [3:0] A;
+input [3:0] B;
+input Li, Ei, Gi;
+output Lo, Eo, Go;
+
+assign Lo = (A < B) || (A == B && !Gi && !Ei);
+assign Go = (A > B) || (A == B && !Li && !Ei);
+assign Eo = (A == B) && Ei;
+
+endmodule
+
 module \74AC283_1x1ADD4 (A, B, CI, S, CO);
 
 input [3:0] A;

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -8,7 +8,7 @@ all: counter.vcd cic5.vcd dspmac_16_40.vcd pwm256.vcd sddac.vcd picorv32.vcd
 
 ../benchmarks/%.v: ;
 
-%.v: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_dffe.v ../74_mux.v ../synth_74.ys
+%.v: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_dffe.v ../74_mux.v ../74_cmp.v ../synth_74.ys
 	yosys -q -s ../synth_74.ys -p "write_verilog $@" $<
 
 %.vvp: %.v ../benchmarks/%_tb.v 74series.v ../74_models.v

--- a/stat/Makefile
+++ b/stat/Makefile
@@ -3,5 +3,5 @@
 all: ../74series.lib VexRiscv.stat picorv32.stat shifter64.stat smartbextdep.stat cordic_10_16.stat \
     arlet_6502.stat axilxbar.stat
 
-%.stat: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_dffe.v ../74_mux.v ../synth_74.ys
+%.stat: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_cmp.v ../74_eq.v ../74_dffe.v ../74_mux.v ../synth_74.ys
 	yosys -q -s ../synth_74.ys -p "tee -o $@ stat" $<

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -11,7 +11,7 @@ dff2dffe -unmap-mince 8
 pmux2shiftx
 read_verilog -lib ../74_models.v
 read_liberty -lib ../74series.lib
-techmap -map ../74_adder.v -map ../74_cmp.v
+techmap -map ../74_adder.v -map ../74_cmp.v -map ../74_eq.v
 synth -run :fine
 opt -full
 # memory_map

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -11,7 +11,7 @@ dff2dffe -unmap-mince 8
 pmux2shiftx
 read_verilog -lib ../74_models.v
 read_liberty -lib ../74series.lib
-techmap -map ../74_adder.v
+techmap -map ../74_adder.v -map ../74_cmp.v
 synth -run :fine
 opt -full
 # memory_map


### PR DESCRIPTION
The initial 7485/74688 techmap proved to *increase* chip count because ABC is rather good at optimizing away unneeded gates.

The first commit merely just fixes the comparator pass to simulate correctly. As far as I can tell this pass generally decreases chip count already.

For the equality techmap I added a check to only apply the mapping when the input arguments are variables rather than constants. Experimentation shows that variables take up much more gates than comparisons with a constant because of constant folding and other optimizations.

The new equality pass matches only one instance in picorv32 and one in VexRiscv, but at leas they actually improve chip count. I verified in the pwm256 benchmark that using an equality there does match the mapping. It just appears most equalities are with constants, and these are usually handled more efficiently by plain logic.

It's entirely possible that a better heuristic can be found for these mappings, but at least now they make things better rather than worse.