### PR TITLE
Hopefully correct NAND gates

### DIFF
--- a/74series.lib
+++ b/74series.lib
@@ -67,7 +67,7 @@ library(74series) {
         pin(A) { direction: input; }
         pin(B) { direction: input; }
         pin(C) { direction: input; }
-        pin(Y) { direction: output; function: "((A*B)'*C)'"; }
+        pin(Y) { direction: output; function: "(A*B*C)'"; }
     }
 
     // 74AC11 triple 3-input AND
@@ -86,7 +86,7 @@ library(74series) {
         pin(B) { direction: input; }
         pin(C) { direction: input; }
         pin(D) { direction: input; }
-        pin(Y) { direction: output; function: "(((A*B)'*C)'*D)'"; }
+        pin(Y) { direction: output; function: "(A*B*C*D)'"; }
     }
 
     // 74AC11032 quad 2-input OR gate


### PR DESCRIPTION
As can be seen from the [74HC20 datasheet](https://assets.nexperia.com/documents/data-sheet/74HC_HCT30.pdf), a multi-port NAND appears to be a tree of AND with an inverter at the end, rather than a tree of NANDs. (noting that due to DeMorgan `(A'+B')'=A*B` the NOR gates actually form an AND)

![image](https://user-images.githubusercontent.com/168609/60972655-f968f200-a326-11e9-9bf8-63c8c8e8f7fb.png)

Might be worth double-checking this change and other gates before I order a picorv32 board ;-)

Note that this change actually degrades the number of cells used across the board. Of course a bigger correct program is better than a smaller incorrect one, but maybe there is something interesting to learn here.
