### PR TITLE
Shift register pass

### DIFF
--- a/74_models.v
+++ b/74_models.v
@@ -44,3 +44,18 @@ output Q;
 assign Q = E || !(A == B);
 
 endmodule
+
+module \74AC164_1x1SHREG8 (DS, MRn, CP, Q);
+
+input [1:0] DS;
+input MRn, CP;
+output reg [7:0] Q;
+
+always @(posedge CP, negedge MRn) begin
+  if (MRn==1'b0)
+    Q = 8'h00;
+  else
+    Q = {&DS, Q[6:0]};
+end
+
+endmodule

--- a/74_shreg.v
+++ b/74_shreg.v
@@ -1,0 +1,18 @@
+
+(* techmap_celltype = "$__SHREG_DFF_P_" *)
+module _80_74AC164(input C, D, output Q);
+parameter DEPTH = 1;
+
+wire [7:0] QBUF;
+wire [1:0] DS;
+
+assign DS = {1'b1, D};
+assign Q = QBUF[DEPTH-1];
+
+\74AC164_1x1SHREG8 _TECHMAP_REPLACE_ (
+    .DS(DS),
+    .MRn(1'b1),
+    .CP(C),
+    .Q(Q),
+);
+endmodule

--- a/74_shreg.v
+++ b/74_shreg.v
@@ -16,3 +16,21 @@ assign Q = QBUF[DEPTH-1];
     .Q(Q),
 );
 endmodule
+
+(* techmap_celltype = "$__SHREG_DFFE_PP_" *)
+module _80_74AC164E(input C, D, E, output Q);
+parameter DEPTH = 1;
+
+wire [7:0] QBUF;
+wire [1:0] DS;
+
+assign DS = {D, E};
+assign Q = QBUF[DEPTH-1];
+
+\74AC164_1x1SHREG8 _TECHMAP_REPLACE_ (
+    .DS(DS),
+    .MRn(1'b1),
+    .CP(C),
+    .Q(Q),
+);
+endmodule

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -16,7 +16,9 @@ synth -run :fine
 opt -full
 # memory_map
 # opt -full
-techmap -map +/techmap.v -map ../74_dffe.v 
+techmap -map +/techmap.v
+shregmap -maxlen 8 -clkpol pos
+techmap -map ../74_shreg.v -map ../74_dffe.v
 opt
 muxcover -mux4 -mux8
 opt

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -7,7 +7,7 @@ opt
 dffsr2dff
 dff2dffe
 opt_merge
-dff2dffe -unmap-mince 8
+#dff2dffe -unmap-mince 8
 pmux2shiftx
 read_verilog -lib ../74_models.v
 read_liberty -lib ../74series.lib
@@ -17,7 +17,8 @@ opt -full
 # memory_map
 # opt -full
 techmap -map +/techmap.v
-shregmap -maxlen 8 -clkpol pos
+shregmap -maxlen 8 -clkpol pos -enpol none
+shregmap -maxlen 8 -clkpol pos -enpol pos
 techmap -map ../74_shreg.v -map ../74_dffe.v
 opt
 muxcover -mux4 -mux8


### PR DESCRIPTION
I was thinking that it is very common in HDL (especially in bit-serial design ;-) to use shift registers. So it seemed like a good idea to add them so I did.

The problem is that 99% of the use-cases I can think of for shift registers require parallel reads and/or writes and most likely init/reset. None of that is supported now. David said if we patch Yosys with a new `-tech` option it might be possible to add some things like that.

So the chip supports parallel output, global clear, and enable. The techpass could in theory support enable with `-enpol`, but I could not make it work.

It is quite telling that in all of the benchmarks, this pass does not get used even once. And even in the synthetic example below, it only transforms 8 flip-flops to one shift register, which is does not help much anyway.

Conclusion: Pretty useless, probably not worth it without more work.
I'll leave it here, but feel free to close the PR.

```
module counter (
  input rst,
  input clk,
  output led
    
);

    /* reg */
    reg [7:0] counter;
    
    /* assign */
    assign led = counter[0];
    always @ (posedge clk) begin
      if (!counter[0])
        counter <= {1'b1, counter[7:1]};
    end

endmodule
```