### PR TITLE
Change liberty buffer type so it gets optimized away

### DIFF
--- a/74series.lib
+++ b/74series.lib
@@ -204,8 +204,9 @@ library(74series) {
         pin(Y) { direction: output; function: "((S'*A)+(S*B))'"; }
     }
 
-    // 74AC11244 octal buffer
-    cell(74AC11244_8x1BUF) {
+    // A buffer cell needed to make ABC happy
+    // Will get optimized away
+    cell("$_BUF_") {
         area: 2;
         pin(A) { direction: input; }
         pin(Y) { direction: output; function: "A"; }


### PR DESCRIPTION
We used to have a 74xx cell for a buffer chip that ABC needs to be happy.
But CMOS tech can have very high fan-out so it seems not really needed.
Changing the cell name to `$_BUF_` actually causes it to be optimised away later, as explained in `help insbuf`