### PR TITLE
Add a counter pass

### DIFF
--- a/74_counter.v
+++ b/74_counter.v
@@ -1,0 +1,27 @@
+(* techmap_celltype = "_74xx_counter8 _74xx_counter16 _74xx_counter32" *)
+module _80_74AC161_counter (rst, clk, preset, counter);
+parameter _TECHMAP_CELLTYPE_ = "";
+parameter WIDTH = (_TECHMAP_CELLTYPE_ == "_74xx_counter8") ? 8 : (_TECHMAP_CELLTYPE_ == "_74xx_counter16" ? 16 : 32) ;
+
+input rst;
+input clk;
+input [WIDTH-1:0] preset;
+output reg [WIDTH-1:0] counter;
+
+wire [WIDTH:0] C;
+assign C[0] = 1'b1;
+
+genvar i;
+generate for (i = 0; i < WIDTH; i = i + 4) begin:slice
+    \74AC161_1x1COUNT4 counter_i(
+        .A(preset[i+3:i]),
+        .Q(counter[i+3:i]),
+        .CLK(clk),
+        .ENT(C[i]),
+        .RCO(C[i+4]),
+        .LOAD(rst)
+    );
+end
+endgenerate
+
+endmodule

--- a/74_extract.il
+++ b/74_extract.il
@@ -1,0 +1,164 @@
+
+autoidx 22
+
+attribute \cells_not_processed 1
+attribute \src "74_extract.v:16"
+module \_74xx_counter16
+
+  attribute \src "74_extract.v:22"
+  wire width 16 $0\counter[15:0]
+
+  attribute \src "74_extract.v:26"
+  wire width 16 $add$74_extract.v:26$6_Y
+
+  attribute \src "74_extract.v:18"
+  wire input 2 \clk
+
+  attribute \src "74_extract.v:20"
+  wire width 16 output 4 \counter
+
+  attribute \src "74_extract.v:19"
+  wire width 16 input 3 \preset
+
+  attribute \src "74_extract.v:17"
+  wire input 1 \rst
+
+  attribute \src "74_extract.v:26"
+  cell $add $add$74_extract.v:26$6
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 16
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 1
+    parameter \Y_WIDTH 16
+    connect \A \counter
+    connect \B 1'1
+    connect \Y $add$74_extract.v:26$6_Y
+  end
+
+  attribute \src "74_extract.v:22"
+  cell $dff $procdff$20
+    parameter \CLK_POLARITY 1'1
+    parameter \WIDTH 16
+    connect \CLK \clk
+    connect \D $0\counter[15:0]
+    connect \Q \counter
+  end
+
+  attribute \full_case 1
+  attribute \src "74_extract.v:23"
+  cell $mux $procmux$14
+    parameter \WIDTH 16
+    connect \A \preset
+    connect \B $add$74_extract.v:26$6_Y
+    connect \S \rst
+    connect \Y $0\counter[15:0]
+  end
+end
+
+attribute \cells_not_processed 1
+attribute \src "74_extract.v:31"
+module \_74xx_counter32
+
+  attribute \src "74_extract.v:37"
+  wire width 32 $0\counter[31:0]
+
+  attribute \src "74_extract.v:41"
+  wire width 32 $add$74_extract.v:41$9_Y
+
+  attribute \src "74_extract.v:33"
+  wire input 2 \clk
+
+  attribute \src "74_extract.v:35"
+  wire width 32 output 4 \counter
+
+  attribute \src "74_extract.v:34"
+  wire width 33 input 3 \preset
+
+  attribute \src "74_extract.v:32"
+  wire input 1 \rst
+
+  attribute \src "74_extract.v:41"
+  cell $add $add$74_extract.v:41$9
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 32
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 1
+    parameter \Y_WIDTH 32
+    connect \A \counter
+    connect \B 1'1
+    connect \Y $add$74_extract.v:41$9_Y
+  end
+
+  attribute \src "74_extract.v:37"
+  cell $dff $procdff$19
+    parameter \CLK_POLARITY 1'1
+    parameter \WIDTH 32
+    connect \CLK \clk
+    connect \D $0\counter[31:0]
+    connect \Q \counter
+  end
+
+  attribute \full_case 1
+  attribute \src "74_extract.v:38"
+  cell $mux $procmux$11
+    parameter \WIDTH 32
+    connect \A \preset [31:0]
+    connect \B $add$74_extract.v:41$9_Y
+    connect \S \rst
+    connect \Y $0\counter[31:0]
+  end
+end
+
+attribute \cells_not_processed 1
+attribute \src "74_extract.v:1"
+module \_74xx_counter8
+
+  attribute \src "74_extract.v:7"
+  wire width 8 $0\counter[7:0]
+
+  attribute \src "74_extract.v:11"
+  wire width 8 $add$74_extract.v:11$3_Y
+
+  attribute \src "74_extract.v:3"
+  wire input 2 \clk
+
+  attribute \src "74_extract.v:5"
+  wire width 8 output 4 \counter
+
+  attribute \src "74_extract.v:4"
+  wire width 8 input 3 \preset
+
+  attribute \src "74_extract.v:2"
+  wire input 1 \rst
+
+  attribute \src "74_extract.v:11"
+  cell $add $add$74_extract.v:11$3
+    parameter \A_SIGNED 0
+    parameter \A_WIDTH 8
+    parameter \B_SIGNED 0
+    parameter \B_WIDTH 1
+    parameter \Y_WIDTH 8
+    connect \A \counter
+    connect \B 1'1
+    connect \Y $add$74_extract.v:11$3_Y
+  end
+
+  attribute \src "74_extract.v:7"
+  cell $dff $procdff$21
+    parameter \CLK_POLARITY 1'1
+    parameter \WIDTH 8
+    connect \CLK \clk
+    connect \D $0\counter[7:0]
+    connect \Q \counter
+  end
+
+  attribute \full_case 1
+  attribute \src "74_extract.v:8"
+  cell $mux $procmux$17
+    parameter \WIDTH 8
+    connect \A \preset
+    connect \B $add$74_extract.v:11$3_Y
+    connect \S \rst
+    connect \Y $0\counter[7:0]
+  end
+end

--- a/74_extract.v
+++ b/74_extract.v
@@ -4,8 +4,6 @@ module _74xx_counter8 (
   input [7:0] preset,
   output reg [7:0] counter
 );
-parameter WIDTH = 8;
-
     always @ (posedge clk) begin
       if (!rst) begin
         counter <= preset;
@@ -21,8 +19,6 @@ module _74xx_counter16 (
   input [15:0] preset,
   output reg [15:0] counter
 );
-parameter WIDTH = 16;
-
     always @ (posedge clk) begin
       if (!rst) begin
         counter <= preset;
@@ -38,8 +34,6 @@ module _74xx_counter32 (
   input [32:0] preset,
   output reg [31:0] counter
 );
-parameter WIDTH = 32;
-
     always @ (posedge clk) begin
       if (!rst) begin
         counter <= preset;

--- a/74_extract.v
+++ b/74_extract.v
@@ -1,0 +1,51 @@
+module _74xx_counter8 (
+  input rst,
+  input clk,
+  input [7:0] preset,
+  output reg [7:0] counter
+);
+parameter WIDTH = 8;
+
+    always @ (posedge clk) begin
+      if (!rst) begin
+        counter <= preset;
+      end else begin
+        counter <= counter + 1'b1;
+      end
+    end
+endmodule
+
+module _74xx_counter16 (
+  input rst,
+  input clk,
+  input [15:0] preset,
+  output reg [15:0] counter
+);
+parameter WIDTH = 16;
+
+    always @ (posedge clk) begin
+      if (!rst) begin
+        counter <= preset;
+      end else begin
+        counter <= counter + 1'b1;
+      end
+    end
+endmodule
+
+module _74xx_counter32 (
+  input rst,
+  input clk,
+  input [32:0] preset,
+  output reg [31:0] counter
+);
+parameter WIDTH = 32;
+
+    always @ (posedge clk) begin
+      if (!rst) begin
+        counter <= preset;
+      end else begin
+        counter <= counter + 1'b1;
+      end
+    end
+endmodule
+

--- a/74_models.v
+++ b/74_models.v
@@ -44,3 +44,22 @@ output Q;
 assign Q = E || !(A == B);
 
 endmodule
+
+module \74AC161_1x1COUNT4 (A, Q, RCO, ENT, CLK, LOAD);
+input [3:0] A;
+input CLK;
+input ENT;
+input LOAD;
+output reg [3:0] Q;
+output RCO;
+
+assign RCO = Q == 4'b1111;
+
+always @ (posedge CLK) begin
+  if (!LOAD) begin
+    Q <= A;
+  end else if (ENT) begin
+    Q <= Q + 1'b1;
+  end
+end
+endmodule

--- a/benchmarks/counter.v
+++ b/benchmarks/counter.v
@@ -16,11 +16,11 @@ module counter (
     assign led = counter[7];
     
     /* always */
-    always @ (posedge clk or negedge rst) begin
+    always @ (posedge clk) begin
       if (!rst) begin
-        counter <= 0;
+        counter <= 8'b0;
       end else begin
-        counter <= counter + 1;
+        counter <= counter + 1'b1;
       end
     end
 

--- a/benchmarks/counter_tb.v
+++ b/benchmarks/counter_tb.v
@@ -13,9 +13,9 @@ module counter_tb ();
     $dumpfile("counter.vcd");
     $dumpvars(0,counter_tb);
     clk = 1'b0;
-    rst = 1'b1;
-    repeat(4) #10 clk = ~clk;
     rst = 1'b0;
+    repeat(4) #10 clk = ~clk;
+    rst = 1'b1;
     repeat(1024) #10 clk = ~clk;
   end
  

--- a/benchmarks/pwmled.v
+++ b/benchmarks/pwmled.v
@@ -18,15 +18,15 @@ assign idx = counter[6:0];
 assign level = counter[15:8];
 assign pwm_out = polarity ^ (idx > level);
 
-always @(posedge clk or negedge rst_n)
+always @(posedge clk)
 begin
-    if (rst_n == 1'b0)
+    if (!rst_n)
     begin
-        counter <= 8'd0;
+        counter <= 16'b0000000000000000;
     end
     else
     begin
-        counter <= counter + 8'd1;
+        counter <= counter + 1'b1;
     end
 end
 

--- a/kicad/generate_netlist.py
+++ b/kicad/generate_netlist.py
@@ -171,6 +171,9 @@ def create_chips(chip_types, nets):
         elif typ == '\\74HC688_1x1EQ8':
             mapping = {"P{}": "A", "R{}": "B", "G": "E", "P=R": "Q"}
             make_techmap(new_74688, mapping, chips, nets, 0)
+        elif typ == '\\74AC161_1x1COUNT4':
+            mapping = {"D{}": "A", "Q{}": "Q", "~PE": "LOAD", "CET": "ENT", "TC": "RCO", "CP": "CLK"}
+            make_techmap(new_74161, mapping, chips, nets, 0)
         else:
             raise Exception("%s not handled" % typ)
 

--- a/kicad/parts.py
+++ b/kicad/parts.py
@@ -166,3 +166,12 @@ def new_74688():
     chip.VCC += VCC
     chip.GND += GND
     return chip
+
+def new_74161():
+    "4-bit counter"
+    chip = skidl.Part('74xx', '74LS161', footprint="Package_DIP:DIP-16_W7.62mm")
+    chip.VCC += VCC
+    chip.GND += GND
+    chip['~MR'] += VCC
+    chip.CEP += VCC
+    return chip

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -1,10 +1,10 @@
 hierarchy -auto-top
 proc
-extract -map ../74_extract.v
 flatten
 opt
 wreduce
 opt
+extract -map ../74_extract.il
 dffsr2dff
 dff2dffe
 opt_merge

--- a/synth_74.ys
+++ b/synth_74.ys
@@ -1,5 +1,6 @@
 hierarchy -auto-top
 proc
+extract -map ../74_extract.v
 flatten
 opt
 wreduce
@@ -11,7 +12,7 @@ dff2dffe -unmap-mince 8
 pmux2shiftx
 read_verilog -lib ../74_models.v
 read_liberty -lib ../74series.lib
-techmap -map ../74_adder.v -map ../74_cmp.v -map ../74_eq.v
+techmap -map ../74_adder.v -map ../74_cmp.v -map ../74_eq.v -map ../74_counter.v
 synth -run :fine
 opt -full
 # memory_map


### PR DESCRIPTION
I asked Clifford and the `extract_counter` pass is just not very good or complete. He suggested I use regular `extract`, which works better but is very specific. So I don't think you can have generic widths.

My current approach is therefore to have an `extract` pass for `counter8`, `counter16`, and `counter32`, followed by a `techmap` pass that turns them into 74AC161 chips. This works fine, but only if your code is exactly the same. In my experience writing `counter + 1` and `counter + 1'b1` already causes a mismatch, even though yosys correctly infers the right number of bits.

So in summary, this pass only really works if you write your code to use it.

I looked at various counter chips, but the 74x161 is one of the few that is widely available. There is the 74x867 which is 8 bits and can count both up and down, but is not available it seems. 74x4040 is 12 bits, which does not jive well with the fixed-width extraction and does not offer preset, limiting its usage as a program counter for example. 74x191 can count down, so might be a worthy alternative that could be looked into, but is not available in 74AC or DIP.

In short, 74x161 is the most practical, but I want the 74x191 for my stack pointers.