### PR TITLE
fix make: `74series.lib` is renamed to `74ac.lib`

### DIFF
--- a/stat/Makefile
+++ b/stat/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all
 
-all: ../74series.lib VexRiscv.stat picorv32.stat shifter64.stat smartbextdep.stat cordic_10_16.stat \
+all: ../74ac.lib VexRiscv.stat picorv32.stat shifter64.stat smartbextdep.stat cordic_10_16.stat \
     arlet_6502.stat axilxbar.stat
 
-%.stat: ../benchmarks/%.v ../74series.lib ../74_models.v ../74_adder.v ../74_cmp.v ../74_eq.v ../74_dffe.v ../74_mux.v ../synth_74.ys
+%.stat: ../benchmarks/%.v ../74ac.lib ../74_models.v ../74_adder.v ../74_cmp.v ../74_eq.v ../74_dffe.v ../74_mux.v ../synth_74.ys
 	yosys -q -s ../synth_74.ys -p "tee -o $@ stat" $<


### PR DESCRIPTION
@pepijndevos Thanks for the nice talk at rc3!

Here's a list of problems I encountered when trying to use this project.

1. When running `make` in `74xx-liberty/stat` I get

```
make: *** No rule to make target `../74series.lib', needed by `all'.  Stop.
```

Looks like the file got renamed to `74ac.lib`, see PR.

2. If the file is renamed, the next problem when using a recent version of yosys (here: https://github.com/YosysHQ/yosys/commit/da1d06d7852a64e562a8a8a75aa8b4c1864bc9e7) is:

```
yosys -q -s ../synth_74.ys -p "tee -o VexRiscv.stat stat" ../benchmarks/VexRiscv.v
../benchmarks/VexRiscv.v:0: Warning: System task `$display' outside initial block is unsupported.
ERROR: No such command: dffsr2dff (type 'help' for a command overview)
make: *** [VexRiscv.stat] Error 1
```

The yosys changelog says:

```
- Merged "dffsr2dff", "opt_rmdff", "dff2dffe", "dff2dffs", "peepopt.dffmux" passes into a new "opt_dff" pass
```

Looks like these passes could be replaced by `opt_dff` in `synth_74.ys`. However, I do not know yosys well enough to know how to deal with the command `dff2dffe -unmap-mince 8`, as the `-unmap-mince 8` parameter does not seem to be available anymore.

To make the script work at all, all uses of `dffsr2dff` and `dff2dffe` can be removed and be replaced by `opt_dff`.